### PR TITLE
test: two tests for get_func_args, closes #1

### DIFF
--- a/scrapy/utils/python.py
+++ b/scrapy/utils/python.py
@@ -215,12 +215,14 @@ def binary_is_text(data: bytes) -> bool:
 def get_func_args(func: Callable[..., Any], stripself: bool = False) -> list[str]:
     """Return the argument name list of a callable object"""
     if not callable(func):
+        # This TypeError hasn't been tested
         raise TypeError(f"func must be callable, got '{type(func).__name__}'")
 
     args: list[str] = []
     try:
         sig = inspect.signature(func)
     except ValueError:
+        # This ValueError hasn't been tested
         return args
 
     if isinstance(func, partial):

--- a/tests/test_utils_python.py
+++ b/tests/test_utils_python.py
@@ -5,6 +5,7 @@ import sys
 
 import pytest
 from twisted.trial import unittest
+from unittest.mock import patch
 
 from scrapy.utils.asyncgen import as_async_generator, collect_asyncgen
 from scrapy.utils.defer import aiter_errback, deferred_f_from_coro_f
@@ -231,6 +232,9 @@ class UtilsPythonTestCase(unittest.TestCase):
         self.assertEqual(get_func_args(object), [])
         self.assertEqual(get_func_args(str.split, stripself=True), ["sep", "maxsplit"])
         self.assertEqual(get_func_args(" ".join, stripself=True), ["iterable"])
+        # The parameter has to be callable, if not, like this 42, it triggers a TypeError,
+        # which was not previously reached.
+        self.assertRaises(TypeError, get_func_args, 42)
 
         if sys.version_info >= (3, 13) or platform.python_implementation() == "PyPy":
             # the correct and correctly extracted signature
@@ -244,6 +248,15 @@ class UtilsPythonTestCase(unittest.TestCase):
                 get_func_args(operator.itemgetter(2), stripself=True),
                 [[], ["args", "kwargs"]],
             )
+
+    @patch('inspect.signature', side_effect=ValueError("some error"))
+    def test_get_func_args_value_error(self, signature):
+        # Test that if inspect.signature raises a ValueError, get_func_args returns an empty list.
+        # This ValueError was not previously reached.
+        def f4(a, b):
+            pass
+        # When inspect.signature raises a ValueError, the function should return [] (args).
+        self.assertEqual(get_func_args(f4), [])
 
     def test_without_none_values(self):
         self.assertEqual(without_none_values([1, None, 3, 4]), [1, 3, 4])


### PR DESCRIPTION
Added two tests for get_func_args, improves coverage from 81% to 94%.